### PR TITLE
Add tests to check that timeout_ops restores correctly

### DIFF
--- a/scrapli/decorators.py
+++ b/scrapli/decorators.py
@@ -304,8 +304,10 @@ def timeout_modifier(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
                 )
                 base_timeout_ops = driver_instance.timeout_ops
                 driver_instance.timeout_ops = kwargs["timeout_ops"]
-                result = wrapped_func(*args, **kwargs)
-                driver_instance.timeout_ops = base_timeout_ops
+                try:
+                    result = wrapped_func(*args, **kwargs)
+                finally:
+                    driver_instance.timeout_ops = base_timeout_ops
             return result
 
     # ensures that the wrapped function is updated w/ the original functions docs/etc. --


### PR DESCRIPTION
# Description

Please include a summary of the change and, if applicable, which issue this change is associated with. Please also
 include relevant motivation and context. List any dependencies that are required for this change.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
 list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project (no GitHub actions complaints! run `make lint` before
 committing!)
- [ ] I have commented my code, pydocstyle and darglint are happy, docstrings are in google docstring format, and all
 docstrings include a summary, args, returns and raises fields (even if N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works, if adding "functional" tests please
 note if there are any considerations for the vrnetlab setup
- [ ] New and existing unit tests pass locally with my changes
